### PR TITLE
correct josh flag(not boolean but string)

### DIFF
--- a/src/components/VideoList/VideoListItem.js
+++ b/src/components/VideoList/VideoListItem.js
@@ -177,7 +177,7 @@ export const VideoListItem = memo(({ sx, videoId, videoTitle, publishedAt, start
           />
         </VideoListDiscription>
       </VideoListListItemButton>
-      {isJosh &&
+      {isJosh === 'true' &&
         <>
           <ChatButton
             onClick={handleClickOpen}


### PR DESCRIPTION
WEBストレージに格納されたjoshフラグはbooleanでなくstring.
booleanのように判定を行うと常にtrueが返るため修正.