### PR TITLE
実況スレ登録状況確認追加

### DIFF
--- a/src/components/PendingThread/PendingThread.js
+++ b/src/components/PendingThread/PendingThread.js
@@ -42,14 +42,17 @@ export const PendingThread = memo(({ sx }) => {
   const [, getTitle] = useGetYoutubeTitle("");
   const [titles, setTitles] = useState({});
   useEffect(() => {
-    let obj = {};
-    Object.keys(pendingData).map(async (key) => {
-      if (key === "") return;
-      if (obj[key]) return;
-      obj[key] = {};
-      obj[key].title = await getTitle(key);
-    });
-    setTitles((titles) => Object.assign(obj, titles));
+    const exec = async () => {
+      let obj = {};
+      await Promise.all(Object.keys(pendingData).map(async (key) => {
+        if (key === "") return;
+        if (obj[key]) return;
+        obj[key] = {};
+        obj[key].title = await getTitle(key);
+      }));
+      setTitles((titles) => Object.assign(obj, titles));
+    };
+    exec();
   }, [pendingData, getTitle]);
 
   return (
@@ -62,14 +65,14 @@ export const PendingThread = memo(({ sx }) => {
       <BodySectionTypography>
         登録して頂いた情報が以下にリアルタイムで反映されます.<br />
         ここから表示が消えればコメント登録が完了しております.<br />
-        ※動画にコメントが反映されていない場合キャッシュを削除すれば反映されるかもしれません※<br /><br />
+        ※動画にコメントが反映されていない場合キャッシュを削除すれば反映されるかもしれません.もしくはバグ※<br /><br />
       </BodySectionTypography>
       {Object.keys(pendingData).map((key, index) => (
         <React.Fragment key={index}>
           <Link href={`https://www.youtube.com/watch?v=${key}`} rel="noopener noreferrer" target="_blank" underline="always">{titles[key]?.title}</Link>
           {pendingData[key].threads.map((thread, i) => (
             <URLTypography key={i}>
-              {`${pendingData[key].threads[i].url}`}<br />
+              {`${thread.url}`}<br />
             </URLTypography>
           ))}
         </React.Fragment>

--- a/src/components/PendingThread/PendingThread.js
+++ b/src/components/PendingThread/PendingThread.js
@@ -1,8 +1,9 @@
 import React, { memo, useEffect, useState } from "react";
+
 import styled from "@emotion/styled";
-import { Box } from "@mui/system";
+import { Box, Link, Typography } from "@mui/material";
+
 import { useRealtimeDBListener } from "../../hooks/useRealtimeDB";
-import { Link, Typography } from "@mui/material";
 import { useGetYoutubeTitle } from "../../hooks/useYoutubeInfo";
 
 //#region ユーザー定義スタイルコンポーネント

--- a/src/components/PendingThread/PendingThread.js
+++ b/src/components/PendingThread/PendingThread.js
@@ -1,0 +1,78 @@
+import React, { memo, useEffect, useState } from "react";
+import styled from "@emotion/styled";
+import { Box } from "@mui/system";
+import { useRealtimeDBListener } from "../../hooks/useRealtimeDB";
+import { Link, Typography } from "@mui/material";
+import { useGetYoutubeTitle } from "../../hooks/useYoutubeInfo";
+
+//#region ユーザー定義スタイルコンポーネント
+const JBox = styled(Box)((theme) => ({
+  width: "100%",
+}));
+
+const SubSectionTypography = styled(Typography)({
+  variant:"h2",
+  fontSize: '1.2rem',
+  marginTop:'1.5rem',
+  marginBottom:'1rem'
+});
+
+const BodySectionTypography = styled(Typography)({
+  variant:"body1",
+  component:"p",
+  fontSize: '1rem',
+});
+
+const URLTypography = styled(Typography)({
+  variant:"body1",
+  component:"p",
+  fontSize: '1rem',
+  marginLeft: 32
+});
+//#endregion
+
+/**
+ * 実況スレ登録待ち確認
+ */
+export const PendingThread = memo(({ sx }) => {
+  // 登録待ち情報取得
+  const [pendingData] = useRealtimeDBListener({"": {threads: []}}, "/thread", "update", true);
+  // タイトル
+  const [, getTitle] = useGetYoutubeTitle("");
+  const [titles, setTitles] = useState({});
+  useEffect(() => {
+    let obj = {};
+    Object.keys(pendingData).map(async (key) => {
+      if (key === "") return;
+      if (obj[key]) return;
+      obj[key] = {};
+      obj[key].title = await getTitle(key);
+    });
+    setTitles((titles) => Object.assign(obj, titles));
+  }, [pendingData, getTitle]);
+
+  return (
+    <JBox
+      sx={sx}
+    >
+      <SubSectionTypography>
+        🧪登録待ち情報🧪
+      </SubSectionTypography>
+      <BodySectionTypography>
+        登録して頂いた情報が以下にリアルタイムで反映されます.<br />
+        ここから表示が消えればコメント登録が完了しております.<br />
+        ※動画にコメントが反映されていない場合キャッシュを削除すれば反映されるかもしれません※<br /><br />
+      </BodySectionTypography>
+      {Object.keys(pendingData).map((key, index) => (
+        <React.Fragment key={index}>
+          <Link href={`https://www.youtube.com/watch?v=${key}`} rel="noopener noreferrer" target="_blank" underline="always">{titles[key]?.title}</Link>
+          {pendingData[key].threads.map((thread, i) => (
+            <URLTypography key={i}>
+              {`${pendingData[key].threads[i].url}`}<br />
+            </URLTypography>
+          ))}
+        </React.Fragment>
+      ))}
+    </JBox>
+  )
+});

--- a/src/components/PlayList/PublicPlayListItem.js
+++ b/src/components/PlayList/PublicPlayListItem.js
@@ -2,8 +2,7 @@ import { memo } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import styled from "@emotion/styled";
-import { ListItem, ListItemButton, ListItemText } from "@mui/material";
-import { Box } from "@mui/system";
+import { Box, ListItem, ListItemButton, ListItemText } from "@mui/material";
 import { format } from "date-fns";
 import { LazyLoadImage } from "react-lazy-load-image-component";
 import { isMobile } from "react-device-detect";

--- a/src/components/RegistThread/RegistThread.js
+++ b/src/components/RegistThread/RegistThread.js
@@ -1,7 +1,7 @@
 import React, { memo, useEffect, useState } from "react";
+
 import styled from "@emotion/styled";
-import { Backdrop, Button, Checkbox, CircularProgress, FormControlLabel, IconButton, Snackbar, Stack, TextField } from "@mui/material";
-import { Box } from "@mui/system";
+import { Backdrop, Box, Button, Checkbox, CircularProgress, FormControlLabel, IconButton, Snackbar, Stack, TextField } from "@mui/material";
 import ClearIcon from '@mui/icons-material/Clear';
 import LockIcon from '@mui/icons-material/Lock';
 import AddIcon from '@mui/icons-material/Add';
@@ -9,8 +9,9 @@ import YouTubeIcon from '@mui/icons-material/YouTube';
 import { Controller, useFieldArray, useForm } from "react-hook-form";
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup'
+
 import { useGetRealtimeDB, useUpdateRealtimeDB } from "../../hooks/useRealtimeDB";
-import axios from "axios";
+import { useGetYoutubeTitle } from "../../hooks/useYoutubeInfo";
 
 //#region ユーザー定義スタイルコンポーネント
 const JBox = styled(Box)((theme) => ({
@@ -202,14 +203,7 @@ export const RegistThread = memo(({ sx, defaultYoutubeURL="" }) => {
   }, [registeredData, setValue]);
 
   // Youtube動画タイトル取得
-   // Youtubeのメタ情報から取得する
-   const [title, setTitle] = useState("");
-   useEffect(() => {
-    if (youtubeId === "") return;
-     const reqURL = `https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${youtubeId}&format=json`;
-     axios.get(reqURL)
-       .then((res) => setTitle(res.data.title));
-   }, [youtubeId]);
+  const [title] = useGetYoutubeTitle(youtubeId)
 
   return (
     <JBox>

--- a/src/components/RegistThread/RegistThreadDialog.js
+++ b/src/components/RegistThread/RegistThreadDialog.js
@@ -1,5 +1,7 @@
-import { Dialog, DialogContent, DialogTitle } from "@mui/material";
 import { memo } from "react";
+
+import { Dialog, DialogContent, DialogTitle } from "@mui/material";
+
 import { RegistThread } from "./RegistThread";
 
 export const RegistThreadDialog = memo((props) => {

--- a/src/components/SideContainer/PlayListSideContainer.js
+++ b/src/components/SideContainer/PlayListSideContainer.js
@@ -1,8 +1,7 @@
 import { memo, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 
-import { List } from "@mui/material";
-import { Box } from "@mui/system";
+import { Box, List } from "@mui/material";
 
 import { PlayListSideContainerIconItem, PlayListSideContainerItem } from "./PlayListSideContainerItem";
 

--- a/src/components/SideContainer/VideoListSideContainer.js
+++ b/src/components/SideContainer/VideoListSideContainer.js
@@ -1,7 +1,6 @@
 import { memo } from "react";
 
-import { List } from "@mui/material";
-import { Box } from "@mui/system";
+import { Box, List } from "@mui/material";
 import { VideoListSideContainerItem } from "./VideoListSideContainerItem";
 /**
  * サイドバーリスト

--- a/src/components/VideoList/VideoListItem.js
+++ b/src/components/VideoList/VideoListItem.js
@@ -7,6 +7,7 @@ import { format, intervalToDuration } from "date-fns";
 import ChatIcon from '@mui/icons-material/Chat';
 import AppRegistrationIcon from '@mui/icons-material/AppRegistration';
 import { isMobile } from "react-device-detect";
+
 import { useLocalStorage } from "../../hooks/useLocalStrage";
 import { RegistThreadDialog } from "../RegistThread/RegistThreadDialog";
 

--- a/src/components/VideoList/VideoListMenu.js
+++ b/src/components/VideoList/VideoListMenu.js
@@ -4,9 +4,9 @@ import { useLocation, useNavigate } from "react-router-dom";
 import styled from "@emotion/styled";
 import { Box, Pagination, Typography } from "@mui/material";
 import queryString from "query-string";
+import { isMobile } from "react-device-detect";
 
 import { SearchBar } from "../SearchBar/SearchBar";
-import { isMobile } from "react-device-detect";
 
 //#region ユーザー定義スタイルコンポーネント
 const VideoListSelect = styled("select")(({ theme }) => ({

--- a/src/components/WatchVideoContents/WatchVideoComments.js
+++ b/src/components/WatchVideoContents/WatchVideoComments.js
@@ -1,15 +1,15 @@
 import { memo, useEffect, useRef, useState } from "react";
 
 import styled from "@emotion/styled";
-import { Box } from "@mui/system";
 import AutoSizer from "react-virtualized-auto-sizer";
 import { FixedSizeList } from "react-window";
 import { format } from "date-fns";
-import { IconButton } from "@mui/material";
+import { Box, IconButton } from "@mui/material";
 import InsertCommentIcon from '@mui/icons-material/InsertComment';
 import CommentsDisabledIcon from '@mui/icons-material/CommentsDisabled';
 import DownloadIcon from '@mui/icons-material/Download';
 import FileDownloadOffIcon from '@mui/icons-material/FileDownloadOff';
+
 import { useLocalStorage } from "../../hooks/useLocalStrage";
 import { isMobile } from "react-device-detect";
 

--- a/src/hooks/useRealtimeDB.js
+++ b/src/hooks/useRealtimeDB.js
@@ -1,6 +1,6 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
-import { get, ref, update } from "firebase/database";
+import { equalTo, get, onValue, orderByChild, query, ref, update } from "firebase/database";
 
 import { realtimedb } from "../libs/InitFirebase";
 
@@ -29,6 +29,28 @@ export function useGetRealtimeDB(
   }, []);
 
   return [data, getData, resetData];
+}
+
+// Realtime Databaseの値イベントリッスンを管理するHOOK
+export function useRealtimeDBListener(
+  initialState,
+  path,
+  filterKey,
+  filterValue
+) {
+  const [data, setData] = useState(initialState);
+
+  // listener
+  useEffect(() => {
+    const dataRef = query(ref(realtimedb, path), orderByChild(filterKey), equalTo(filterValue));
+    onValue(dataRef, (snapshot) => {
+      const val = snapshot.val();
+      if (!val) return;
+      setData(val);
+    })
+  }, [path, filterKey, filterValue, setData]);
+
+  return [data];
 }
 
 /**

--- a/src/hooks/useYoutubeInfo.js
+++ b/src/hooks/useYoutubeInfo.js
@@ -1,0 +1,27 @@
+import axios from "axios";
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Youtube動画情報を管理するHOOK
+ */
+export function useGetYoutubeTitle(videoId) {
+  const [title, setTitle] = useState("");
+  useEffect(() => {
+    if (!videoId) {
+      setTitle("");
+      return;
+    }
+    const reqURL = `https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${videoId}&format=json`;
+    axios.get(reqURL)
+      .then((res) => setTitle(res.data.title));
+  }, [videoId]);
+
+  const getTitle = useCallback(async (id) => {
+    if (id === "") return "";
+    const reqURL = `https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${id}&format=json`;
+    const res = await axios.get(reqURL);
+    return res.data.title;
+  }, []);
+
+  return [title, getTitle];
+}

--- a/src/pages/JPage.js
+++ b/src/pages/JPage.js
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { Typography } from "@mui/material";
 import { Box } from "@mui/system";
+import { PendingThread } from "../components/PendingThread/PendingThread";
 import { RegistThread } from "../components/RegistThread/RegistThread";
 
 //#region ユーザー定義スタイルコンポーネント
@@ -29,6 +30,7 @@ export default function JPage() {
         実況スレ登録ページです. 定期的に実行される処理にてコメントに反映されます.
       </BodySectionTypography>
       <RegistThread />
+      <PendingThread sx={{ pt: 5 }} />
     </JBox>
   );
 }

--- a/src/pages/JPage.js
+++ b/src/pages/JPage.js
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
-import { Typography } from "@mui/material";
-import { Box } from "@mui/system";
+import { Box, Typography } from "@mui/material";
 import { PendingThread } from "../components/PendingThread/PendingThread";
 import { RegistThread } from "../components/RegistThread/RegistThread";
 

--- a/src/pages/JPage.js
+++ b/src/pages/JPage.js
@@ -11,6 +11,12 @@ const JBox = styled(Box)({
   paddingBottom: 40
 });
 
+const SubSectionTypography = styled(Typography)({
+  variant:"h2",
+  fontSize: '1.2rem',
+  marginBottom:'1rem'
+});
+
 const BodySectionTypography = styled(Typography)({
   variant:"body1",
   component:"p",
@@ -25,8 +31,14 @@ const BodySectionTypography = styled(Typography)({
 export default function JPage() {
   return (
     <JBox>
+      <SubSectionTypography>
+        🧪実況スレ登録🧪
+      </SubSectionTypography>
       <BodySectionTypography>
-        実況スレ登録ページです. 定期的に実行される処理にてコメントに反映されます.
+        Youtubeの動画に5ch実況スレを登録することができます.<br />
+        現在は１時間に１動画分のコメント生成を行っています.<br /><br />
+        「同時視聴」はこよりの配信がないときに開始時間を合わせて実況したスレを登録する際に使用します.<br />
+        ※旧スプシの同時視聴／現スプシのセルフに対応します※<br />
       </BodySectionTypography>
       <RegistThread />
       <PendingThread sx={{ pt: 5 }} />

--- a/src/pages/MobileVideoPage.js
+++ b/src/pages/MobileVideoPage.js
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
-import { Box } from "@mui/system";
+
+import { Box } from "@mui/material";
 
 import { VideoList } from "../components/VideoList/VideoList";
 import { useFireStorage } from "../hooks/useFireStorage";

--- a/src/pages/VideoPage.js
+++ b/src/pages/VideoPage.js
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Box } from "@mui/system";
+import { Box } from "@mui/material";
 
 import { VideoList } from "../components/VideoList/VideoList";
 import { VideoListSideContainer } from "../components/SideContainer/VideoListSideContainer";

--- a/src/pages/WatchPage.js
+++ b/src/pages/WatchPage.js
@@ -1,12 +1,11 @@
-import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import styled from "@emotion/styled";
 import { Box } from "@mui/material";
-import axios from "axios";
 
 import { WatchVideoHeader } from "../components/WatchVideoContents/WatchVideoHeader";
 import { WatchVideoMain } from "../components/WatchVideoContents/WatchVideoMain";
+import { useGetYoutubeTitle } from "../hooks/useYoutubeInfo";
 
 const WatchPageFullWidth = styled(Box)({
   maxWidth: 1664,
@@ -27,13 +26,7 @@ export default function WatchPage() {
 
   // 動画タイトルの取得
   // Youtubeのメタ情報から取得する
-  const [title, setTitle] = useState("");
-  useEffect(() => {
-    if (!videoid) return;
-    const reqURL = `https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${videoid}&format=json`;
-    axios.get(reqURL)
-      .then((res) => setTitle(res.data.title));
-  }, [videoid]);
+  const [title] = useGetYoutubeTitle(videoid);
 
   return (
     <WatchPageFullWidth>


### PR DESCRIPTION
実況スレの登録状況を確認できるようにコンポーネントを追加.
現状匿名投稿のため未処理データのみ表示する簡易機能に留める.
リアルタイムで確認ができるようデータベースのイベントリスナーを追加.