### PR TITLE
add channelID to thread registration

### DIFF
--- a/src/components/RegistThread/RegistThread.js
+++ b/src/components/RegistThread/RegistThread.js
@@ -11,7 +11,7 @@ import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup'
 
 import { useGetRealtimeDB, useUpdateRealtimeDB } from "../../hooks/useRealtimeDB";
-import { getVideoTitle } from "../../libs/initYoutube";
+import { getVideoTitle, getChannelId } from "../../libs/initYoutube";
 
 //#region ユーザー定義スタイルコンポーネント
 const JBox = styled(Box)((theme) => ({
@@ -146,6 +146,7 @@ export const RegistThread = memo(({ sx, defaultYoutubeURL="" }) => {
 
     json.threads = [...registeredData.threads, ...data.threads];
     json.update = true;
+    json.channelId = channelId;
     updateThreadData(`/thread/${youtubeId}`, json);
     // 送信後フォームのリセットを行う
     reset({
@@ -210,6 +211,16 @@ export const RegistThread = memo(({ sx, defaultYoutubeURL="" }) => {
       setTitle(res);
     };
     getTitle();
+  }, [youtubeId]);
+
+  // Youtube動画に紐付くチャンネルID取得
+  const [channelId, setChannelId] = useState("");
+  useEffect(() => {
+    const getChannelIdFunc = async() => {
+      const res = await getChannelId(youtubeId);
+      setChannelId(res);
+    };
+    getChannelIdFunc();
   }, [youtubeId]);
 
   return (

--- a/src/libs/initYoutube.js
+++ b/src/libs/initYoutube.js
@@ -14,6 +14,16 @@ export const getVideoTitle = async (videoId) => {
 }
 
 /**
+ * Youtube動画のチャンネルIDを取得
+ */
+export const getChannelId = async (videoId) => {
+  if (!videoId) return "";
+  const req = `${YOUTUBE_API_URL}videos?part=snippet&id=${videoId}&key=${process.env.REACT_APP_FIREBASE_APIKEY}`;
+  const res = await axios.get(req);
+  return res.data.items[0].snippet.channelId;
+}
+
+/**
  * Youtube動画からコメントスレッドを取得
  */
 export const getVideoCommentThreads = async (videoId) => {


### PR DESCRIPTION
再生リストおよび動画リストにこより以外のチャンネルの動画を追加するための更新：
こより以外のチャンネルの動画に実況スレを登録してもリスト上に反映されなかったため、
実況スレ登録時に動画に紐付くチャンネル情報も持たせる。
表示対象のリスト自体はGithub Actions側で別途生成する。
